### PR TITLE
Created variables. Should be passing travis-ci on correctness now.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Ansible Role: Vim
 
 [![Build Status](https://travis-ci.com/mattladany/ansible-role-vim.svg?branch=master)](https://travis-ci.com/mattladany/ansible-role-vim)
+[!(https://img.shields.io/ansible/role/39137.svg)](https://galaxy.ansible.com/mattladany/vim)
 [![License](https://img.shields.io/badge/License-MIT-blue.svg)](https://raw.githubusercontent.com/mattladany/ansible-role-vim/master/LICENSE)
 
 Installs the latest (or specified) [vim](https://github.com/vim/vim) 'release' from source on Ubuntu16.04 and Centos7 systems.
@@ -35,13 +36,13 @@ The url to download the vim tarball from.
 
 Whether the latest version of vim should be found and installed, or if the specified version should be used.
 
-**IMPORTANT:** getting the latest version may have unreliable results without pairing an SSH key with Github, since Github blocks too many requests from the same IP address without one (this is why many of my early travis-ci tests failed). See [here](https://help.github.com/en/articles/generating-a-new-ssh-key-and-adding-it-to-the-ssh-agent) for how to set up a new SSH key.
+**IMPORTANT:** getting the latest version may have unreliable results without pairing an SSH key with Github, since Github blocks too many requests from the same IP address without one (this is why many of my early travis-ci tests failed). See [here](https://help.github.com/en/articles/generating-a-new-ssh-key-and-adding-it-to-the-ssh-agent) for how to set up a new SSH key with Github.
 
-```base_dir: /usr/local/src```
+```vim_download_dir: /usr/local/src```
 
 Where the tarball should be downloaded to.
 
-```vim_base_dir: {{ base_dir }}/vim```
+```vim_src_dir: {{ vim_download_dir }}/vim```
 
 Where the tarball should be untar'd to.
 

--- a/README.md
+++ b/README.md
@@ -3,28 +3,70 @@
 [![Build Status](https://travis-ci.com/mattladany/ansible-role-vim.svg?branch=master)](https://travis-ci.com/mattladany/ansible-role-vim)
 [![License](https://img.shields.io/badge/License-MIT-blue.svg)](https://raw.githubusercontent.com/mattladany/ansible-role-vim/master/LICENSE)
 
-Installs the latest [Vim](https://github.com/vim/vim) release from source on Ubuntu16.04/Centos7 operating systems.
+Installs the latest (or specified) [vim](https://github.com/vim/vim) 'release' from source on Ubuntu16.04 and Centos7 systems.
 
-**Note:** Many of the steps and packages that get installed by this role were taken from this [YouCompleteMe](https://github.com/Valloric/YouCompleteMe/wiki/Building-Vim-from-source) wiki. 
+There are many plugins for vim that require a version of vim greater than 8.0, and most repos for Debian/RedHat systems only come with 7.4, so this role attempts to solve this problem by reliably installing a vim version (or the latest vim version) from source. Although the installation instructions are laid out very nicely by [this](https://github.com/Valloric/YouCompleteMe/wiki/Building-Vim-from-source) wiki, I have found some weird caveats still occur and are solved by this role.
 
 ## Requirements
 
-None
+The requirements to compile vim from source are highly dependent upon simply what you want vim compiled with. Currently, this role compiles vim with all possible options, and installs all the requirements for you:
+
+- git
+- lua
+- python3
+- ruby
+- perl
+
+For a full list, see the ```_vim_dependencies``` variable in the [vars](https://github.com/mattladany/ansible-role-vim/tree/master/vars)/OS.yml for your operating system.
 
 ## Role Variables
 
-None
+Available variables are listed below, along with their default values (see ```defaults/main.yml```):
+
+```vim_version: v8.1.1057```
+
+Set this to the version of vim you would like to install. The default will continually get more up-to-date as this role has new releases. See [here](https://github.com/vim/vim/releases) for a list of the latest vim releases.
+
+```vim_tarball_url: https://github.com/vim/vim/tarball/{{ vim_version }}```
+
+The url to download the vim tarball from.
+
+```vim_latest: false```
+
+Whether the latest version of vim should be found and installed, or if the specified version should be used.
+
+**IMPORTANT:** getting the latest version may have unreliable results without pairing an SSH key with Github, since Github blocks too many requests from the same IP address without one (this is why many of my early travis-ci tests failed). See [here](https://help.github.com/en/articles/generating-a-new-ssh-key-and-adding-it-to-the-ssh-agent) for how to set up a new SSH key.
+
+```base_dir: /usr/local/src```
+
+Where the tarball should be downloaded to.
+
+```vim_base_dir: {{ base_dir }}/vim```
+
+Where the tarball should be untar'd to.
 
 ## Dependencies
 
 None
 
-## Example Playbook
+## Example Playbooks
+
+### Installing a specific version
 
 ```
 - hosts: servers
-    roles:
-      - { role: mattladany.vim }
+  become: yes
+  roles:
+    - { role: mattladany.vim, vim_version: v8.1.1057 }
+```
+
+### Installing the latest version
+
+```
+- hosts: servers
+  become: yes
+  roles:
+    - { role: mattladany.vim, latest: yes }
 ```
 
 ## License

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,6 +1,15 @@
 ---
 # defaults file for ansible-role-vim
 
+# The version of vim to install
+vim_version: v8.1.1057
+
+# The tarball to to download
+vim_tarball_url: "https://github.com/vim/vim/tarball/{{ vim_version }}"
+
+# Whether the latest version of vim should be installed on not
+vim_latest: false
+
 # Where the tarball should be downloaded to
 base_dir: /usr/local/src
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -11,7 +11,7 @@ vim_tarball_url: "https://github.com/vim/vim/tarball/{{ vim_version }}"
 vim_latest: false
 
 # Where the tarball should be downloaded to
-base_dir: /usr/local/src
+vim_download_dir: /usr/local/src
 
 # Where the tarball should be unpacked to
-vim_base_dir: "{{ base_dir }}/vim"
+vim_src_dir: "{{ vim_download_dir }}/vim"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,2 +1,8 @@
 ---
 # defaults file for ansible-role-vim
+
+# Where the tarball should be downloaded to
+base_dir: /usr/local/src
+
+# Where the tarball should be unpacked to
+vim_base_dir: "{{ base_dir }}/vim"

--- a/tasks/Debian.yml
+++ b/tasks/Debian.yml
@@ -3,26 +3,7 @@
 
 - name: install necessary vim packages
   apt:
-    name:
-    - wget
-    - git
-    - curl
-    - libgnome2-dev
-    - libgnomeui-dev
-    - libgtk2.0-dev
-    - libatk1.0-dev
-    - libcairo2-dev
-    - libx11-dev
-    - libxpm-dev
-    - python3
-    - python3-dev
-    - lua5.1
-    - liblua5.1-dev
-    - libperl-dev
-    - cmake
-    - make
-    - mono-xbuild
-    - ruby-dev
+    name: "{{ vim_dependencies }}"
     state: present
 
 - name: uninstall vim 7.4 (pre-installed with Debian systems)

--- a/tasks/Debian.yml
+++ b/tasks/Debian.yml
@@ -1,12 +1,12 @@
 ---
 # tasks for Debian systems
 
-- name: install necessary vim packages
+- name: Ensure the given packages are installed
   apt:
     name: "{{ vim_dependencies }}"
     state: present
 
-- name: uninstall vim 7.4 (pre-installed with Debian systems)
+- name: Ensure vim 7.4 is not installed (pre-installed with Debian systems)
   apt:
     name: vim
     state: absent

--- a/tasks/RedHat.yml
+++ b/tasks/RedHat.yml
@@ -6,18 +6,18 @@
     name: epel-release
     state: present
 
-- name: install packages needed for vim
+- name: Ensure the necessary vim packages are installed
   yum:
     name: "{{ vim_dependencies }}"
     state: present
 
-- name: create symlink for xsubpp
+- name: Ensure the symlink for xsubpp is created
   file:
     src: /usr/bin/xsubpp
     dest: /usr/share/perl5/ExtUtils/xsubpp
     state: link
 
-- name: Ensure vim 7.4 is not installed.
+- name: Ensure vim 7.4 is not installed
   yum:
     name: vim
     state: absent

--- a/tasks/RedHat.yml
+++ b/tasks/RedHat.yml
@@ -8,31 +8,7 @@
 
 - name: install packages needed for vim
   yum:
-    name:
-    - wget
-    - ncurses
-    - ncurses-devel
-    - cmake
-    - make
-    - mono-addins-devel
-    - gcc-c++
-    - ruby
-    - ruby-devel
-    - lua
-    - lua-devel
-    - luajit
-    - luajit-devel
-    - ctags
-    - git
-    - python34
-    - python34-devel
-    - tcl-devel
-    - perl
-    - perl-devel
-    - perl-ExtUtils-ParseXS
-    - perl-ExtUtils-XSpp
-    - perl-ExtUtils-CBuilder
-    - perl-ExtUtils-Embed
+    name: "{{ vim_dependencies }}"
     state: present
 
 - name: create symlink for xsubpp
@@ -40,3 +16,8 @@
     src: /usr/bin/xsubpp
     dest: /usr/share/perl5/ExtUtils/xsubpp
     state: link
+
+- name: Ensure vim 7.4 is not installed.
+  yum:
+    name: vim
+    state: absent

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -4,27 +4,27 @@
 - name: get the list of tags
   uri:
     url: https://api.github.com/repos/vim/vim/tags
-    dest: /usr/local/src/tags
-    creates: /usr/local/src/tags
+    dest: "{{ base_dir }}/tags"
+    creates: "{{ base_dir }}/tags"
   register: tags
 
 - name: download the vim tarball
   get_url:
     url: "{{ tags.json[0].tarball_url }}"
-    dest: /usr/local/src/vim.tar.gz
+    dest: "{{ base_dir }}vim.tar.gz"
   when: tags.json is defined
 
 - name: untar
   unarchive:
-    src: /usr/local/src/vim.tar.gz
-    dest: /usr/local/src
+    src: "{{ base_dir }}vim.tar.gz"
+    dest: "{{ base_dir }}"
     remote_src: yes
-    creates: /usr/local/src/vim
+    creates: "{{ vim_base_dir }}"
 
 - name: change the name of the vim-vim-* directory to vim/
-  shell: mv /usr/local/src/vim-vim* /usr/local/src/vim
+  shell: "mv /usr/local/src/vim-vim* {{ vim_base_dir }}"
   args:
-    creates: /usr/local/src/vim
+    creates: "{{ vim_base_dir }}"
 
 - name: configure
   command: './configure \
@@ -39,6 +39,6 @@
     --enable-cscope \
     --prefix=/usr/local'
   args:
-    chdir: /usr/local/src/vim
-    creates: /usr/local/src/vim/src/auto/config.h
+    chdir: "{{ vim_base_dir }}"
+    creates: "{{ vim_base_dir }}/src/auto/config.h"
   notify: install

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -32,7 +32,7 @@
     --enable-multibyte \
     --enable-rubyinterp=yes \
     --enable-python3interp=yes \
-    --with-python3-config-dir={{ python3_dir }} \
+    --with-python3-config-dir={{ vim_python3_dir }} \
     --enable-perlinterp=yes \
     --enable-luainterp=yes \
     --enable-gui=gtk2 \

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -1,39 +1,44 @@
 ---
 # tasks for installing vim from source
 
-- name: get the list of tags
+- name: Ensure the vim_download_dir exists
+  file:
+    path: "{{ vim_download_dir }}"
+    state: directory
+
+- name: Retrieve the latest list of tags
   uri:
     url: https://api.github.com/repos/vim/vim/tags
-    dest: "{{ base_dir }}/tags"
-    creates: "{{ base_dir }}/tags"
+    dest: "{{ vim_download_dir }}/tags"
+    creates: "{{ vim_download_dir }}/tags"
   register: tags
   when: vim_latest
 
-- name: download the vim tarball
+- name: Ensure the latest vim tarball is downloaded
   get_url:
     url: "{{ tags.json[0].tarball_url }}"
-    dest: "{{ base_dir }}/vim.tar.gz"
+    dest: "{{ vim_download_dir }}/vim.tar.gz"
   when: tags.json is defined
 
-- name: download the vim tarball
+- name: Ensure the specified vim tarball is downloaded
   get_url:
     url: "{{ vim_tarball_url }}"
-    dest: "{{ base_dir }}/vim.tar.gz"
+    dest: "{{ vim_download_dir }}/vim.tar.gz"
   when: not vim_latest
 
-- name: untar
+- name: Untar the download
   unarchive:
-    src: "{{ base_dir }}/vim.tar.gz"
-    dest: "{{ base_dir }}"
+    src: "{{ vim_download_dir }}/vim.tar.gz"
+    dest: "{{ vim_download_dir }}"
     remote_src: yes
-    creates: "{{ vim_base_dir }}"
+    creates: "{{ vim_src_dir }}"
 
-- name: change the name of the vim-vim-* directory to vim/
-  shell: "mv /usr/local/src/vim-vim* {{ vim_base_dir }}"
+- name: Move the vim-vim-* directory to {{ vim_src_dir }}
+  shell: "mv {{ vim_download_dir}}/vim-vim* {{ vim_src_dir }}"
   args:
-    creates: "{{ vim_base_dir }}"
+    creates: "{{ vim_src_dir }}"
 
-- name: configure
+- name: Run ./configure if it has not been run already
   command: './configure \
     --with-features=huge \
     --enable-multibyte \
@@ -46,6 +51,6 @@
     --enable-cscope \
     --prefix=/usr/local'
   args:
-    chdir: "{{ vim_base_dir }}"
-    creates: "{{ vim_base_dir }}/src/auto/config.h"
+    chdir: "{{ vim_src_dir }}"
+    creates: "{{ vim_src_dir }}/src/auto/config.h"
   notify: install

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -7,16 +7,23 @@
     dest: "{{ base_dir }}/tags"
     creates: "{{ base_dir }}/tags"
   register: tags
+  when: vim_latest
 
 - name: download the vim tarball
   get_url:
     url: "{{ tags.json[0].tarball_url }}"
-    dest: "{{ base_dir }}vim.tar.gz"
+    dest: "{{ base_dir }}/vim.tar.gz"
   when: tags.json is defined
+
+- name: download the vim tarball
+  get_url:
+    url: "{{ vim_tarball_url }}"
+    dest: "{{ base_dir }}/vim.tar.gz"
+  when: not vim_latest
 
 - name: untar
   unarchive:
-    src: "{{ base_dir }}vim.tar.gz"
+    src: "{{ base_dir }}/vim.tar.gz"
     dest: "{{ base_dir }}"
     remote_src: yes
     creates: "{{ vim_base_dir }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -4,6 +4,8 @@
 - name: Include OS-specific variables.
   include_vars: "{{ ansible_os_family }}.yml"
 
+- include_tasks: setup-variables.yml
+
 - include_tasks: "{{ ansible_os_family }}.yml"
 
-- include_tasks: source-install.yml
+- include_tasks: install.yml

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,7 +1,7 @@
 ---
 # tasks file for vim
 
-- name: Include OS-specific variables.
+- name: Include OS-specific variables
   include_vars: "{{ ansible_os_family }}.yml"
 
 - include_tasks: setup-variables.yml

--- a/tasks/setup-variables.yml
+++ b/tasks/setup-variables.yml
@@ -9,3 +9,4 @@
 - name: Define vim_python3_dir.
   set_fact:
     vim_python3_dir: "{{ _vim_python3_dir }}"
+  when: vim_python3_dir is not defined

--- a/tasks/setup-variables.yml
+++ b/tasks/setup-variables.yml
@@ -1,12 +1,12 @@
 ---
 # setup this role's variables
 
-- name: Define vim_dependencies.
+- name: Define vim_dependencies
   set_fact:
     vim_dependencies: "{{ _vim_dependencies | list }}"
   when: vim_dependencies is not defined
 
-- name: Define vim_python3_dir.
+- name: Define vim_python3_dir
   set_fact:
     vim_python3_dir: "{{ _vim_python3_dir }}"
   when: vim_python3_dir is not defined

--- a/tasks/setup-variables.yml
+++ b/tasks/setup-variables.yml
@@ -1,0 +1,11 @@
+---
+# setup this role's variables
+
+- name: Define vim_dependencies.
+  set_fact:
+    vim_dependencies: "{{ _vim_dependencies | list }}"
+  when: vim_dependencies is not defined
+
+- name: Define vim_python3_dir.
+  set_fact:
+    vim_python3_dir: "{{ _vim_python3_dir }}"

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -1,4 +1,25 @@
 ---
 # Debian-specific vars
 
-python3_dir: /usr/lib/python3/config
+_vim_dependencies:
+  - wget
+  - git
+  - curl
+  - libgnome2-dev
+  - libgnomeui-dev
+  - libgtk2.0-dev
+  - libatk1.0-dev
+  - libcairo2-dev
+  - libx11-dev
+  - libxpm-dev
+  - python3
+  - python3-dev
+  - lua5.1
+  - liblua5.1-dev
+  - libperl-dev
+  - cmake
+  - make
+  - mono-xbuild
+  - ruby-dev
+
+_vim_python3_dir: /usr/lib/python3/config

--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -1,4 +1,30 @@
 ---
 # RedHat-specfic variables
 
-python3_dir: /lib64/python3/config
+_vim_dependencies:
+  - wget
+  - ncurses
+  - ncurses-devel
+  - cmake
+  - make
+  - mono-addins-devel
+  - gcc-c++
+  - ruby
+  - ruby-devel
+  - lua
+  - lua-devel
+  - luajit
+  - luajit-devel
+  - ctags
+  - git
+  - python34
+  - python34-devel
+  - tcl-devel
+  - perl
+  - perl-devel
+  - perl-ExtUtils-ParseXS
+  - perl-ExtUtils-XSpp
+  - perl-ExtUtils-CBuilder
+  - perl-ExtUtils-Embed
+
+_vim_python3_dir: /lib64/python3/config


### PR DESCRIPTION
Now using variables to provide more flexibility.
Since the default is now to install the specified 'release' of vim as opposed to the latest 'release', travis should no longer fail due to denied API requests like it used to.
