### PR TITLE
Updated dependencies for Debian buster

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ script:
     || (echo 'Idempotence test: fail' && exit 1)
 
   # Check if vim installed successfully
-  - "if [[ ! $(vim --version | grep 8.1) ]]; then echo 'vim did not install successfully'; exit 1; fi"
+  - "if [[ ! $(vim --version | grep 8.2) ]]; then echo 'vim did not install successfully'; exit 1; fi"
 
   # Check if vim was compiled with the specified dependencies
   - "if [[ ! $(vim --version | grep +python3) ]]; then echo 'vim did not compile with python3 successfully'; exit 1; fi"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,7 +2,7 @@
 # defaults file for ansible-role-vim
 
 # The version of vim to install
-vim_version: v8.1.1330
+vim_version: v8.2.1687
 
 # The tarball to to download
 vim_tarball_url: "https://github.com/vim/vim/tarball/{{ vim_version }}"
@@ -17,7 +17,7 @@ vim_download_dir: /usr/local/src
 vim_src_dir: "{{ vim_download_dir }}/vim"
 
 # The VIMRUNTIMEDIR make variable
-vim_runtime_dir: /usr/local/share/vim/vim81
+vim_runtime_dir: /usr/local/share/vim/vim82
 
 compile_with:
   lua: true

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -6,13 +6,12 @@ _vim_dependencies:
     - wget
     - git
     - curl
-    - libgnome2-dev
-    - libgnomeui-dev
     - libgtk2.0-dev
     - libatk1.0-dev
     - libcairo2-dev
     - libx11-dev
     - libxpm-dev
+    - libxt-dev
     - cmake
     - make
     - mono-xbuild


### PR DESCRIPTION
The role was failing when installing the packages, as they no longer exist:
-   libgnome2-dev
-   libgnomeui-dev

On Debian Buster (10).